### PR TITLE
starter content (merge only after the second mongodb-snapshot PR is approved and published)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,21 @@ The codebases located in the `backend` and `frontend` folders should be treated 
 
 To simplify dependency management, this repository includes several root-level scripts for convenience. The `postinstall` script automatically installs dependencies for both the `frontend` and `backend` folders when you run `npm install` at the root. Additionally, you can use the update script to run `npm update` in both codebases, and the `build` script to build both projects.
 
-#### For local Development
-- To start, execute `npm install` from a terminal in the root of this repo
+#### For Local Development
+- To start, execute `npm install` from a terminal in the root of this repo.
+- Next, run `npm run load-starter-content` to fetch a starter database and a little bit of starter media to go with it. You will also be prompted to set an admin password.
 - Next, open a terminal instance at the root of each folder (`frontend` and `backend`). Each project needs to be provided with an `APOS_EXTERNAL_FRONT_KEY` environment variable set to the same string value in order to authenticate communication. For example, in each terminal execute `export APOS_EXTERNAL_FRONT_KEY=my-secret-key`.
 - The `astro.config.mjs` file is already set to the normal default values, but if you are running the backend server on a different port, you will also have to set the `APOS_HOST` environment variable.
 - Then, you can start the projects using the accompanying scripts. For example, in a local development environment you can start each with `npm run dev`.
+
+#### If you don't want to use the starter content
+If you prefer to start with an empty database, you can just add an admin user instead.
+
+In your `backend` terminal window:
+
+```bash
+node app @apostrophecms/user:add admin admin
+```
 
 ### Similarities to a stand-alone ApostropheCMS project
 If you have worked with an ApostropheCMS project previously, the backend repo should look as expected. There are a number of custom modules, providing new pages, pieces, and widgets, located in the `modules` folder. The project also configures several Apostrophe core modules through code located in the `modules/@apostrophecms` folder. For a full understanding of Apostrophe you should consult the [documentation](https://docs.apostrophecms.org/), but we will touch on a few highlights later in this document.

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,9 @@
     "build": "NODE_ENV=production node app @apostrophecms/asset:build",
     "serve": "NODE_ENV=production node app",
     "release": "npm install && npm run build && npm run migrate",
-    "migrate": "NODE_ENV=production node app @apostrophecms/migration:migrate"
+    "migrate": "NODE_ENV=production node app @apostrophecms/migration:migrate",
+    "load-starter-content": "./scripts/load-starter-content",
+    "update-starter-content": "./scripts/update-starter-content"
   },
   "engines": {
     "node": "22.x",
@@ -50,6 +52,7 @@
     "@apostrophecms/seo": "^1.3.0",
     "@apostrophecms/vite": "^1.0.0",
     "apostrophe": "github:apostrophecms/apostrophe",
+    "@apostrophecms/mongodb-snapshot": "^1.1.0",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {

--- a/backend/scripts/load-starter-content
+++ b/backend/scripts/load-starter-content
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ -z "$APOS_MONGODB_URI" ]; then
+  APOS_MONGODB_URI="mongodb://localhost:27017/apollo"
+fi
+
+curl -o /tmp/starter-database.snapshot https://static.apostrophecms.com/apollo/starter-database.snapshot &&
+mongodb-snapshot-read --erase --from=/tmp/starter-database.snapshot --to=$APOS_MONGODB_URI &&
+curl -o /tmp/starter-uploads.tar https://static.apostrophecms.com/apollo/starter-uploads.tar &&
+mkdir -p public/uploads &&
+(cd public/uploads && tar -xf /tmp/starter-uploads.tar) &&
+echo "Starter content loaded. Now set an admin password." &&
+node app @apostrophecms/user:add admin admin

--- a/backend/scripts/update-starter-content
+++ b/backend/scripts/update-starter-content
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Our team uses this script to update the starter content. You may
+# safely remove this script from your own project
+
+if [ -z "$APOS_MONGODB_URI" ]; then
+  APOS_MONGODB_URI="mongodb://localhost:27017/apollo"
+fi
+
+mongodb-snapshot-write --to=/tmp/starter-database.snapshot --from=$APOS_MONGODB_URI \
+  --exclude=aposUsersSafe,aposLocks,aposBearerTokens,aposCache,aposNotifications,sessions \
+  --filter-aposDocs='{"type":{"$ne":"@apostrophecms/user"}}' &&
+scp /tmp/starter-database.snapshot static@static.apostrophecms.com:/opt/static/static/apollo/starter-database.snapshot &&
+tar -cf /tmp/starter-uploads.tar -C ./public/uploads . &&
+scp /tmp/starter-uploads.tar static@static.apostrophecms.com:/opt/static/static/apollo/starter-uploads.tar &&
+echo "Starter content updated."

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build-backend": "echo '\\n💡 running npm run build in backend/' && cd backend && npm run build",
     "migrate": "cd backend && npm run migrate",
     "serve-frontend": "cd frontend && npm run serve",
-    "serve-backend": "cd backend && npm run serve"
+    "serve-backend": "cd backend && npm run serve",
+    "load-starter-content": "cd backend && npm run load-starter-content"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Depends on version 1.1.0 which isn't published yet (works great with `npm link` already).