### PR TITLE
Adds image options back to image widget

### DIFF
--- a/frontend/src/widgets/ImageWidget.astro
+++ b/frontend/src/widgets/ImageWidget.astro
@@ -20,7 +20,7 @@ import {
   getHeight
 } from '../lib/attachments.js';
 
-const { widget } = Astro.props;
+const { widget, imageOptions } = Astro.props;
 const placeholder = widget?.aposPlaceholder;
 const image = widget?._image?.[0];
 
@@ -53,7 +53,7 @@ const aspectRatio = width && height ? `${width}/${height}` : undefined;
 </style>
 
 <img
-  class="img-widget mb-6"
+class={`img-widget mb-6 ${imageOptions?.additionalClasses || ''}`}
   src={src}
   alt={alt}
   loading="lazy"


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
Somehow the template for the image widget was never utilizing the extra props being passed through the AposArea helper. This PR fixes that. This is primarily for teaching purposes, but does alter the author image wherever it is being displayed (blog pages). 

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
