### PR TITLE
fix: add engines field requiring node >= 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   ],
   "author": "Apostrophe Technologies Inc.",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "bugs": {
     "url": "https://github.com/apostrophecms/combined-astro-starter-kit/issues"
   },


### PR DESCRIPTION
Added engines field to package.json specifying node >= 22.0.0. Refs apostrophecms/apostrophe#4645

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Please indicate which branch this PR should merge into:
*Check one*

- [x] main
- [ ] Check if this PR will be resubmitted against another branch

## Summary

Added an `engines` field to `package.json` requiring `node >= 22.0.0`. This ensures users are warned about incompatible Node.js versions before installation. Refs apostrophecms/apostrophe#4645

## What are the specific steps to test this change?

1. Clone the repo and run `npm install` with Node.js 18 — confirm the EBADENGINE warning fires
2. Run `npm install` with Node.js 22 or 24 — confirm no warnings appear

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] Build-related changes

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

**Other information:**
Change suggested by @boutell in apostrophecms/apostrophe#4645.